### PR TITLE
#293 Allow more than one restApiServiceCall for a datapoint

### DIFF
--- a/SchemaDatabase/SGr/Product/RestApiTypes.xsd
+++ b/SchemaDatabase/SGr/Product/RestApiTypes.xsd
@@ -38,7 +38,17 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
     </annotation>    
     <sequence>
       <element name="dataType" type="sgr:RestApiDataType" />
-      <element name="restApiServiceCall" type="sgr:RestApiServiceCall" />
+      <choice>
+        <element name="restApiServiceCall" type="sgr:RestApiServiceCall"/>
+        <sequence>
+          <element name="restApiWriteServiceCall" type="sgr:RestApiServiceCall"/>
+          <element name="restApiReadServiceCall" type="sgr:RestApiServiceCall" minOccurs="0"/>
+        </sequence>
+        <sequence>
+          <element name="restApiReadServiceCall" type="sgr:RestApiServiceCall"/>
+          <element name="restApiWriteServiceCall" type="sgr:RestApiServiceCall" minOccurs="0"/>
+        </sequence>
+      </choice>
     </sequence>
   </complexType>
 


### PR DESCRIPTION
Allow more than one restApiServiceCall for a datapoint

With this possible combinations are

- only `restApiServiceCall` (old version)
- only `restApiReadServiceCall` for R datapoints
- only `restApiWriteServiceCall` for W datapoints
- both `restApiReadServiceCall` and `restApiWriteServiceCall` for RW datapoints
