### PR TITLE
#295 Add mapping for value for RestAPI

### DIFF
--- a/SchemaDatabase/SGr/Product/RestApiTypes.xsd
+++ b/SchemaDatabase/SGr/Product/RestApiTypes.xsd
@@ -61,8 +61,8 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
       <documentation>Maps one value to another value</documentation>
     </annotation>
     <sequence>
-      <element name="from" type="string"/>
-      <element name="to" type="string"/>
+      <element name="genericValue" type="string"/>
+      <element name="deviceValue" type="string"/>
     </sequence>
   </complexType>
 

--- a/SchemaDatabase/SGr/Product/RestApiTypes.xsd
+++ b/SchemaDatabase/SGr/Product/RestApiTypes.xsd
@@ -56,6 +56,25 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
     </restriction>
   </simpleType>
 
+  <complexType name="ValueMapping">
+    <annotation>
+      <documentation>Maps one value to another value</documentation>
+    </annotation>
+    <sequence>
+      <element name="from" type="string"/>
+      <element name="to" type="string"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="RestApiValueMapping">
+    <annotation>
+      <documentation>Maps more values to other values</documentation>
+    </annotation>
+    <sequence>
+      <element name="mapping" type="sgr:ValueMapping" maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+  
   <complexType name="RestApiServiceCall">
     <sequence>
       <element name="requestHeader" type="sgr:HeaderList" minOccurs="0" />
@@ -63,6 +82,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
       <element name="requestPath" type="string" minOccurs="0" />
       <element name="requestBody" type="string" minOccurs="0" />
       <element name="responseQuery" type="sgr:ResponseQuery" minOccurs="0" />
+      <element name="valueMapping" type="sgr:RestApiValueMapping" minOccurs="0" />
     </sequence>
   </complexType>
 

--- a/SchemaDatabase/SGr/Product/RestApiTypes.xsd
+++ b/SchemaDatabase/SGr/Product/RestApiTypes.xsd
@@ -68,7 +68,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
 
   <complexType name="RestApiValueMapping">
     <annotation>
-      <documentation>Maps more values to other values</documentation>
+      <documentation>Maps from generic interface to device specific values.</documentation>
     </annotation>
     <sequence>
       <element name="mapping" type="sgr:ValueMapping" maxOccurs="unbounded" />


### PR DESCRIPTION
Added mapping for value for RestAPI

It is now possible to have a mapping for read and write for a rest api datapoint.

Example:
```
<valueMapping>
  <mapping>
    <from>off</from>
    <to>false</to>
  </mapping>
  <mapping>
    <from>on</from>
    <to>true</to>
  </mapping>
</valueMapping>
```

For a write data call, the generic value is mapped with the mapping and the mapped value is written to the rest api.

For a read data call, the value is read from the rest api and then mapped to the generic value.
