### PR TITLE
added TLS parameters to MessageBrokerListElement.

### DIFF
--- a/SchemaDatabase/SGr/Product/MessagingTypes.xsd
+++ b/SchemaDatabase/SGr/Product/MessagingTypes.xsd
@@ -46,6 +46,8 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
     <sequence>
       <element name="host" type="string" />
       <element name="port" type="string" />
+      <element name="tls" minOccurs="0" type="boolean" />
+      <element name="tlsVerifyCertificate" minOccurs="0" type="boolean" />
     </sequence>
   </complexType>
 


### PR DESCRIPTION
"tls" should default to true, "tlsVerifyCertificate" to false, in order to be backwards compatible.