### PR TITLE
Fixes regex pattern of unsignedIntParameter

### DIFF
--- a/SchemaDatabase/SGr/Generic/BaseTypes.xsd
+++ b/SchemaDatabase/SGr/Generic/BaseTypes.xsd
@@ -916,7 +916,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
 
   <simpleType name="unsignedIntParameter">
     <restriction base="string">
-      <pattern value="\{\{.+\}\}|^\[0..9]+$" />
+      <pattern value="\{\{.+\}\}|^[0..9]+$" />
     </restriction>
   </simpleType>
 

--- a/SchemaDatabase/SGr/Generic/SGrSerialIntCapability.xsd
+++ b/SchemaDatabase/SGr/Generic/SGrSerialIntCapability.xsd
@@ -26,7 +26,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
   </simpleType>
   <simpleType name="BaudRateParameter">
     <restriction base="string">
-      <pattern value="\{\{.+\}\}|300|600|1200|2400|4800|5600|9600|14400|19200|38400|57600|115200|12800|230400|256000" />
+      <pattern value="\{\{.+\}\}|300|600|1200|2400|4800|5600|9600|14400|19200|38400|57600|115200|128000|230400|256000" />
     </restriction>
   </simpleType>
   <simpleType name="ByteLength">

--- a/SchemaDatabase/SGr/Product/ModbusTypes.xsd
+++ b/SchemaDatabase/SGr/Product/ModbusTypes.xsd
@@ -150,7 +150,8 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
         (code:3) WriteSingleHoldingRegister (code:6) WriteMultipleHoldingRegisters (code:16) the
         enum "Primitives" means, that the current register Type supports Single Trasnactions If
         dpSizeNrRegistarts is &gt;1, also the multiple access functions must be supported </documentation>
-    </annotation>    <restriction base="string">
+    </annotation>
+    <restriction base="string">
       <enumeration value="Primitives">
         <annotation>
           <documentation> "Primitives" support ReadDiscreteInputs (code: 2) ReadCoils (code: 1)


### PR DESCRIPTION
I found this issue when trying _xjc_. It seems the pattern wasnot valid, even though _EMF_ did not complain.
This fixes the pattern of unsignedIntParameter and also the pattern of baudrateParameter (added missing option).