### PR TITLE
Add optional parameter restApiVerifyCertificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vs
 /.idea
 /.project
 /*.iml

--- a/SchemaDatabase/SGr/Product/RestApiTypes.xsd
+++ b/SchemaDatabase/SGr/Product/RestApiTypes.xsd
@@ -9,7 +9,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
 
   <complexType name="RestApiInterfaceDescription">
     <annotation>
-      <documentation>Modbus interface properties</documentation>
+      <documentation>Rest Api interface properties</documentation>
     </annotation>
     <sequence>
       <element name="restApiInterfaceSelection" type="sgr:RestApiInterfaceSelection" />
@@ -18,6 +18,7 @@ https://github.com/SmartgridReady/SGrSpecifications  -->
         minOccurs="0" />
       <element name="restApiBearer" type="sgr:RestApiBearer" minOccurs="0" />
       <element name="restApiBasic" type="sgr:RestApiBasic" minOccurs="0" />
+      <element name="restApiVerifyCertificate" type="boolean" minOccurs="0" />
     </sequence>
   </complexType>
 


### PR DESCRIPTION
- added _optional_ parameter `restApiVerifyCertificate` to REST interface description
- some minor corrections

Certificate verification is still enabled by default, but can be overridden on a per-device basis.
It might be useful in local networks, where devices often only have a self-signed certificate.