### PR TITLE
Fix EI-XML for ABB-B23 meters.

### DIFF
--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
@@ -55,8 +55,8 @@
     <softwareRevision>1.0.0</softwareRevision>
     <hardwareRevision>1.0.0</hardwareRevision>
     <brandName>B23</brandName>
-    <levelOfOperation>m</levelOfOperation>
     <generalRemarks>Standard Modbus RTU Variant</generalRemarks>
+    <levelOfOperation>m</levelOfOperation>
     <versionNumber>
       <primaryVersionNumber>0</primaryVersionNumber>
       <secondaryVersionNumber>3</secondaryVersionNumber>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
@@ -55,8 +55,8 @@
     <softwareRevision>1.0.0</softwareRevision>
     <hardwareRevision>1.0.0</hardwareRevision>
     <brandName>B23</brandName>
-    <levelOfOperation>m</levelOfOperation>
     <generalRemarks>Modbus TCP variant instead of RTU, only for internal testing</generalRemarks>
+    <levelOfOperation>m</levelOfOperation>
     <versionNumber>
       <primaryVersionNumber>0</primaryVersionNumber>
       <secondaryVersionNumber>3</secondaryVersionNumber>


### PR DESCRIPTION
<generalRemarks> is at the wrong position.