### PR TITLE
Various EID and FP Corrections

### DIFF
--- a/XMLInstances/ExtInterfaces/FullEi4Modbus_0_0036_0030_4_0.1_SGCP_BiDirFlexMgmt.xml
+++ b/XMLInstances/ExtInterfaces/FullEi4Modbus_0_0036_0030_4_0.1_SGCP_BiDirFlexMgmt.xml
@@ -49,7 +49,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
@@ -618,7 +618,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>84825</maximumValue>
+                <maximumValue>84.825</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -648,7 +648,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -678,7 +678,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -708,7 +708,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1095,7 +1095,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20480</address>
                 <registerType>HoldRegister</registerType>
@@ -1127,7 +1127,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21600</address>
                 <registerType>HoldRegister</registerType>
@@ -1159,7 +1159,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21604</address>
                 <registerType>HoldRegister</registerType>
@@ -1191,7 +1191,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21608</address>
                 <registerType>HoldRegister</registerType>
@@ -1239,7 +1239,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Blindenergie</textElement>
                   <language>de</language>
@@ -1247,7 +1247,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20482</address>
                 <registerType>HoldRegister</registerType>
@@ -1267,7 +1267,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 1</textElement>
                   <language>de</language>
@@ -1275,7 +1275,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21636</address>
                 <registerType>HoldRegister</registerType>
@@ -1295,7 +1295,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 2</textElement>
                   <language>de</language>
@@ -1303,7 +1303,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21640</address>
                 <registerType>HoldRegister</registerType>
@@ -1323,7 +1323,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 3</textElement>
                   <language>de</language>
@@ -1331,7 +1331,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21644</address>
                 <registerType>HoldRegister</registerType>
@@ -1407,7 +1407,7 @@
               </genericAttributeList>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20480</address>
                 <registerType>HoldRegister</registerType>
@@ -1445,7 +1445,7 @@
               </genericAttributeList>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20484</address>
                 <registerType>HoldRegister</registerType>
@@ -1526,7 +1526,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20492</address>
                 <registerType>HoldRegister</registerType>
@@ -1550,7 +1550,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20496</address>
                 <registerType>HoldRegister</registerType>
@@ -1612,7 +1612,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1630,7 +1630,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1648,7 +1648,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1666,7 +1666,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusRTU_V0.3.xml
@@ -3,7 +3,7 @@
 <DeviceFrame xmlns="http://www.smartgridready.com/ns/V0/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/Product/Product.xsd">
-  <deviceName>betaABBMeterV0.3.0</deviceName>
+  <deviceName>ABB B23 RTU</deviceName>
   <manufacturerName>ABB</manufacturerName>
   <specificationOwnerIdentification>0</specificationOwnerIdentification>
   <releaseNotes>
@@ -68,7 +68,7 @@
     <configurationListElement>
       <name>slave_id</name>
       <dataType>
-        <int16/>
+        <int16 />
       </dataType>
       <defaultValue>1</defaultValue>
       <configurationDescription>
@@ -80,7 +80,7 @@
     <configurationListElement>
       <name>serial_port</name>
       <dataType>
-        <string/>
+        <string />
       </dataType>
       <defaultValue></defaultValue>
       <configurationDescription>
@@ -93,14 +93,30 @@
       <name>serial_baudrate</name>
       <dataType>
         <enum>
-          <enumEntry><literal>1200</literal></enumEntry>
-          <enumEntry><literal>2400</literal></enumEntry>
-          <enumEntry><literal>4800</literal></enumEntry>
-          <enumEntry><literal>9600</literal></enumEntry>
-          <enumEntry><literal>19200</literal></enumEntry>
-          <enumEntry><literal>38400</literal></enumEntry>
-          <enumEntry><literal>57600</literal></enumEntry>
-          <enumEntry><literal>115200</literal></enumEntry>
+          <enumEntry>
+            <literal>1200</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>2400</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>4800</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>9600</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>19200</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>38400</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>57600</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>115200</literal>
+          </enumEntry>
         </enum>
       </dataType>
       <defaultValue>19200</defaultValue>
@@ -114,11 +130,17 @@
       <name>serial_parity</name>
       <dataType>
         <enum>
-          <enumEntry><literal>EVEN</literal></enumEntry>
-          <enumEntry><literal>ODD</literal></enumEntry>
-          <enumEntry><literal>NONE</literal></enumEntry>
+          <enumEntry>
+            <literal>EVEN</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>ODD</literal>
+          </enumEntry>
+          <enumEntry>
+            <literal>NONE</literal>
+          </enumEntry>
         </enum>
-        </dataType>
+      </dataType>
       <defaultValue>NONE</defaultValue>
       <configurationDescription>
         <textElement>The parity when accessed via serial port.</textElement>
@@ -131,7 +153,7 @@
     <genericAttributeListElement>
       <name>SpecialQualityRequirement</name>
       <dataType>
-        <string/>
+        <string />
       </dataType>
       <value>METAS</value>
       <unit>NONE</unit>
@@ -139,7 +161,7 @@
     <genericAttributeListElement>
       <name>PrecisionPercent</name>
       <dataType>
-        <float32/>
+        <float32 />
       </dataType>
       <value>2.0</value>
       <unit>PERCENT</unit>
@@ -594,7 +616,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>84825</maximumValue>
                 <legibleDescription>
@@ -624,7 +646,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -654,7 +676,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -684,7 +706,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -739,7 +761,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -767,7 +789,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <alternativeNames>
                   <manufName>Totale Blindleistung</manufName>
                 </alternativeNames>
@@ -798,7 +820,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -826,7 +848,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -854,13 +876,13 @@
             <functionalProfileName>ApparentPowerAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ApparentPowerAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>2</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <alternativeNames>
@@ -879,7 +901,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -907,7 +929,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -935,7 +957,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -963,7 +985,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1189,12 +1211,12 @@
             <functionalProfileName>ReactiveEnergyAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
                 <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
@@ -1334,8 +1356,8 @@
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
@@ -1353,7 +1375,7 @@
             <genericAttributeListElement>
               <name>SpecialQualityRequirement</name>
               <dataType>
-                <string/>
+                <string />
               </dataType>
               <value>2014/32/EU : MeasuRIng Instruments Directive, B(Cl.1)</value>
               <unit>NONE</unit>
@@ -1377,7 +1399,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1415,7 +1437,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1454,7 +1476,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1590,7 +1612,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1608,7 +1630,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1626,7 +1648,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1644,7 +1666,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
@@ -561,7 +561,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>84825</maximumValue>
+                <maximumValue>84.825</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -591,7 +591,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -621,7 +621,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -651,7 +651,7 @@
                 </dataType>
                 <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>28275</maximumValue>
+                <maximumValue>28.275</maximumValue>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1038,7 +1038,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20480</address>
                 <registerType>HoldRegister</registerType>
@@ -1070,7 +1070,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21600</address>
                 <registerType>HoldRegister</registerType>
@@ -1102,7 +1102,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21604</address>
                 <registerType>HoldRegister</registerType>
@@ -1134,7 +1134,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21608</address>
                 <registerType>HoldRegister</registerType>
@@ -1182,7 +1182,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Blindenergie</textElement>
                   <language>de</language>
@@ -1190,7 +1190,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20482</address>
                 <registerType>HoldRegister</registerType>
@@ -1210,7 +1210,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 1</textElement>
                   <language>de</language>
@@ -1218,7 +1218,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21636</address>
                 <registerType>HoldRegister</registerType>
@@ -1238,7 +1238,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 2</textElement>
                   <language>de</language>
@@ -1246,7 +1246,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21640</address>
                 <registerType>HoldRegister</registerType>
@@ -1266,7 +1266,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE_HOURS</unit>
                 <legibleDescription>
                   <textElement>Erfassung der Blindenergie Phase 3</textElement>
                   <language>de</language>
@@ -1274,7 +1274,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>21644</address>
                 <registerType>HoldRegister</registerType>
@@ -1350,7 +1350,7 @@
               </genericAttributeList>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20480</address>
                 <registerType>HoldRegister</registerType>
@@ -1388,7 +1388,7 @@
               </genericAttributeList>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20484</address>
                 <registerType>HoldRegister</registerType>
@@ -1469,7 +1469,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20492</address>
                 <registerType>HoldRegister</registerType>
@@ -1493,7 +1493,7 @@
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
-                  <int64 />
+                  <int64U />
                 </modbusDataType>
                 <address>20496</address>
                 <registerType>HoldRegister</registerType>
@@ -1555,7 +1555,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1573,7 +1573,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1591,7 +1591,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1609,7 +1609,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_ModbusTCP_V0.3.xml
@@ -3,7 +3,7 @@
 <DeviceFrame xmlns="http://www.smartgridready.com/ns/V0/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/Product/Product.xsd">
-  <deviceName>betaABBMeterTcpV0.3.0</deviceName>
+  <deviceName>ABB B23 TCP</deviceName>
   <manufacturerName>ABB</manufacturerName>
   <specificationOwnerIdentification>0</specificationOwnerIdentification>
   <releaseNotes>
@@ -68,7 +68,7 @@
     <configurationListElement>
       <name>slave_id</name>
       <dataType>
-        <int16/>
+        <int16 />
       </dataType>
       <defaultValue>1</defaultValue>
       <configurationDescription>
@@ -80,9 +80,9 @@
     <configurationListElement>
       <name>tcp_address</name>
       <dataType>
-        <string/>
+        <string />
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>
@@ -92,7 +92,7 @@
     <configurationListElement>
       <name>tcp_port</name>
       <dataType>
-        <int32/>
+        <int32 />
       </dataType>
       <defaultValue>502</defaultValue>
       <configurationDescription>
@@ -106,7 +106,7 @@
     <genericAttributeListElement>
       <name>SpecialQualityRequirement</name>
       <dataType>
-        <string/>
+        <string />
       </dataType>
       <value>METAS</value>
       <unit>NONE</unit>
@@ -114,7 +114,7 @@
     <genericAttributeListElement>
       <name>PrecisionPercent</name>
       <dataType>
-        <float32/>
+        <float32 />
       </dataType>
       <value>2.0</value>
       <unit>PERCENT</unit>
@@ -559,7 +559,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>84825</maximumValue>
                 <legibleDescription>
@@ -589,7 +589,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -619,7 +619,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -649,7 +649,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>28275</maximumValue>
                 <legibleDescription>
@@ -704,7 +704,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -732,7 +732,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <alternativeNames>
                   <manufName>Totale Blindleistung</manufName>
                 </alternativeNames>
@@ -763,7 +763,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -791,7 +791,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -819,13 +819,13 @@
             <functionalProfileName>ApparentPowerAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ApparentPowerAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>2</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <alternativeNames>
@@ -844,7 +844,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -872,7 +872,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -900,7 +900,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -928,7 +928,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1154,12 +1154,12 @@
             <functionalProfileName>ReactiveEnergyAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
                 <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
@@ -1299,8 +1299,8 @@
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
@@ -1318,7 +1318,7 @@
             <genericAttributeListElement>
               <name>SpecialQualityRequirement</name>
               <dataType>
-                <string/>
+                <string />
               </dataType>
               <value>2014/32/EU : MeasuRIng Instruments Directive, B(Cl.1)</value>
               <unit>NONE</unit>
@@ -1342,7 +1342,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1380,7 +1380,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1419,7 +1419,7 @@
                 <genericAttributeListElement>
                   <name>PrecisionPercent</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1555,7 +1555,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1573,7 +1573,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1591,7 +1591,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1609,7 +1609,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_V0.2.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_V0.2.xml
@@ -3,7 +3,7 @@
 <DeviceFrame xmlns="http://www.smartgridready.com/ns/V0/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/Product/Product.xsd">
-  <deviceName>ABB B23 RTU</deviceName>
+  <deviceName>ABB B23 Beta</deviceName>
   <manufacturerName>ABB</manufacturerName>
   <specificationOwnerIdentification>0</specificationOwnerIdentification>
   <releaseNotes>
@@ -123,7 +123,7 @@
             <functionalProfileName>VoltageAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>VoltageAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
@@ -140,14 +140,14 @@
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL1_N</dataPointName>
+                <dataPointName>VoltageL1</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L1 Spannung gegenüber Nulleiter</manufName>
+                  <manufName>L1 Spannung</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -167,14 +167,14 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL2_N</dataPointName>
+                <dataPointName>VoltageL2</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L2 Spannung gegenüber Nulleiter</manufName>
+                  <manufName>L2 Spannung</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -194,14 +194,14 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL3_N</dataPointName>
+                <dataPointName>VoltageL3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L3 Spannung gegenüber Nulleiter</manufName>
+                  <manufName>L3 Spannung</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -221,7 +221,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL1_L2</dataPointName>
+                <dataPointName>VoltageACL1-L2</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -248,7 +248,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL1_L3</dataPointName>
+                <dataPointName>VoltageACL1-L3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -275,7 +275,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL2_L3</dataPointName>
+                <dataPointName>VoltageACL2-L3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -518,7 +518,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATTS</unit>
+                <unit>WATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -546,7 +546,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATTS</unit>
+                <unit>WATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -574,7 +574,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATTS</unit>
+                <unit>WATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -602,7 +602,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATTS</unit>
+                <unit>WATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -655,7 +655,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -683,7 +683,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES_REACTIVE</unit>
                 <alternativeNames>
                   <manufName>Totale Blindleistung</manufName>
                 </alternativeNames>
@@ -714,7 +714,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -742,7 +742,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -770,7 +770,7 @@
             <functionalProfileName>ApparentPowerAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>ApparentPowerAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
@@ -795,7 +795,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -823,7 +823,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -851,7 +851,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -879,7 +879,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+                <unit>VOLT_AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1041,12 +1041,12 @@
             <functionalProfileName>ReactiveEnergyAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>2</secondaryVersionNumber>
+                <secondaryVersionNumber>1</secondaryVersionNumber>
                 <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
@@ -1155,7 +1155,7 @@
             <functionalProfileName>ActiveEnergyBalanceAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>ActiveEnergyBalanceAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
@@ -1305,7 +1305,7 @@
             <functionalProfileName>ReactiveEnergyBalanceAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyBalanceAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
@@ -1395,7 +1395,7 @@
             <functionalProfileName>PowerQuadrant</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>Metering</functionalProfileCategory>
+              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
               <functionalProfileType>PowerQuadrant</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
@@ -1408,12 +1408,12 @@
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PowerQuadrantACtot</dataPointName>
+                <dataPointName>PwrQuadACtot</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1426,12 +1426,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PowerQuadrantACL1</dataPointName>
+                <dataPointName>PwrQuadACL1</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1444,12 +1444,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PowerQuadrantACL2</dataPointName>
+                <dataPointName>PwrQuadACL2</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1462,12 +1462,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PowerQuadrantACL3</dataPointName>
+                <dataPointName>PwrQuadACL3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>NONE</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_V0.2.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_0016_dddd_ABB_B23_V0.2.xml
@@ -3,7 +3,7 @@
 <DeviceFrame xmlns="http://www.smartgridready.com/ns/V0/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/Product/Product.xsd">
-  <deviceName>betaABBMeterV0.1.2</deviceName>
+  <deviceName>ABB B23 RTU</deviceName>
   <manufacturerName>ABB</manufacturerName>
   <specificationOwnerIdentification>0</specificationOwnerIdentification>
   <releaseNotes>
@@ -68,7 +68,7 @@
     <genericAttributeListElement>
       <name>SpecialQualityRequirement</name>
       <dataType>
-        <string/>
+        <string />
       </dataType>
       <value>METAS</value>
       <unit>NONE</unit>
@@ -76,7 +76,7 @@
     <genericAttributeListElement>
       <name>Precision</name>
       <dataType>
-        <float32/>
+        <float32 />
       </dataType>
       <value>2.0</value>
       <unit>PERCENT</unit>
@@ -123,13 +123,13 @@
             <functionalProfileName>VoltageAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>VoltageAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>2</secondaryVersionNumber>
-                <subReleaseVersionNumber>3</subReleaseVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
@@ -140,14 +140,14 @@
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageL1</dataPointName>
+                <dataPointName>VoltageACL1_N</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L1 Spannung</manufName>
+                  <manufName>L1 Spannung gegenüber Nulleiter</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -167,14 +167,14 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageL2</dataPointName>
+                <dataPointName>VoltageACL2_N</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L2 Spannung</manufName>
+                  <manufName>L2 Spannung gegenüber Nulleiter</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -194,14 +194,14 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageL3</dataPointName>
+                <dataPointName>VoltageACL3_N</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
                 <unit>VOLTS</unit>
                 <alternativeNames>
-                  <manufName>L3 Spannung</manufName>
+                  <manufName>L3 Spannung gegenüber Nulleiter</manufName>
                 </alternativeNames>
               </dataPoint>
               <modbusDataPointConfiguration>
@@ -221,7 +221,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL1-L2</dataPointName>
+                <dataPointName>VoltageACL1_L2</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -248,7 +248,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL1-L3</dataPointName>
+                <dataPointName>VoltageACL1_L3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -275,7 +275,7 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>VoltageACL2-L3</dataPointName>
+                <dataPointName>VoltageACL2_L3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
@@ -381,7 +381,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -409,7 +409,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -437,7 +437,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -465,7 +465,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>KILOWATT_HOURS</unit>
+                <unit>AMPERES</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -518,7 +518,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -546,7 +546,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -574,7 +574,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -602,7 +602,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -655,7 +655,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -683,7 +683,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <alternativeNames>
                   <manufName>Totale Blindleistung</manufName>
                 </alternativeNames>
@@ -714,7 +714,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -742,7 +742,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES_REACTIVE</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -770,13 +770,13 @@
             <functionalProfileName>ApparentPowerAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ApparentPowerAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>2</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <alternativeNames>
@@ -795,7 +795,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -823,7 +823,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -851,7 +851,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -879,7 +879,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>VOLT_AMPERES</unit>
+                <unit>KILOVOLT_AMPERES_REACTIVE</unit>
                 <legibleDescription>
                   <textElement>textElement</textElement>
                   <language>de</language>
@@ -1041,12 +1041,12 @@
             <functionalProfileName>ReactiveEnergyAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
                 <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
@@ -1152,16 +1152,16 @@
         </functionalProfileListElement>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>ActiveEnerBalanceAC</functionalProfileName>
+            <functionalProfileName>ActiveEnergyBalanceAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ActiveEnergyBalanceAC</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <secondaryVersionNumber>2</secondaryVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
@@ -1176,7 +1176,7 @@
             <genericAttributeListElement>
               <name>SpecialQualityRequirement</name>
               <dataType>
-                <float32/>
+                <float32 />
               </dataType>
               <value>2014/32/EU : MeasuRIng Instruments Directive, B(Cl.1)</value>
               <unit>NONE</unit>
@@ -1200,7 +1200,7 @@
                 <genericAttributeListElement>
                   <name>Precision</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1238,7 +1238,7 @@
                 <genericAttributeListElement>
                   <name>Precision</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1277,7 +1277,7 @@
                 <genericAttributeListElement>
                   <name>Precision</name>
                   <dataType>
-                    <float32/>
+                    <float32 />
                   </dataType>
                   <value>1.0</value>
                   <unit>PERCENT</unit>
@@ -1302,13 +1302,11 @@
         </functionalProfileListElement>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>ReactiveEnerBalanceAC</functionalProfileName>
+            <functionalProfileName>ReactiveEnergyBalanceAC</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>ReactiveEnergyBalanceAC</functionalProfileType>
-              <!--ReactiveEnerBalanceAC
-            must be added to FP family-->
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
@@ -1397,27 +1395,25 @@
             <functionalProfileName>PowerQuadrant</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+              <functionalProfileCategory>Metering</functionalProfileCategory>
               <functionalProfileType>PowerQuadrant</functionalProfileType>
-              <!--PowerQuadrant
-            must be added to FP family-->
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
-                <secondaryVersionNumber>2</secondaryVersionNumber>
-                <subReleaseVersionNumber>1</subReleaseVersionNumber>
+                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <subReleaseVersionNumber>2</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PwrQuadACtot</dataPointName>
+                <dataPointName>PowerQuadrantACtot</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1430,12 +1426,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PwrQuadACL1</dataPointName>
+                <dataPointName>PowerQuadrantACL1</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1448,12 +1444,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PwrQuadACL2</dataPointName>
+                <dataPointName>PowerQuadrantACL2</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>
@@ -1466,12 +1462,12 @@
             </dataPointListElement>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>PwrQuadACL3</dataPointName>
+                <dataPointName>PowerQuadrantACL3</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>NONE</unit>
+                <unit>KILOWATT_HOURS</unit>
               </dataPoint>
               <modbusDataPointConfiguration>
                 <modbusDataType>

--- a/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_MQTT_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_MQTT_V0.1.xml
@@ -187,7 +187,7 @@
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>TemperatureSensor</functionalProfileCategory>
-              <functionalProfileType>AmbientTemperature</functionalProfileType>
+              <functionalProfileType>Temperature</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
@@ -249,7 +249,7 @@
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>Sensor</functionalProfileCategory>
-              <functionalProfileType>AmbientHumidity</functionalProfileType>
+              <functionalProfileType>Humidity</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
@@ -278,7 +278,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>PERCENT</unit>
+                <unit>PERCENT_RELATIVE_HUMIDITY</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>100</maximumValue>
                 <legibleDescription>

--- a/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_RestAPICloud_V0.1.xml
@@ -181,7 +181,7 @@
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>TemperatureSensor</functionalProfileCategory>
-              <functionalProfileType>AmbientTemperature</functionalProfileType>
+              <functionalProfileType>Temperature</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
@@ -258,7 +258,7 @@
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>Sensor</functionalProfileCategory>
-              <functionalProfileType>AmbientHumidity</functionalProfileType>
+              <functionalProfileType>Humidity</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
@@ -287,7 +287,7 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>PERCENT</unit>
+                <unit>PERCENT_RELATIVE_HUMIDITY</unit>
                 <minimumValue>0</minimumValue>
                 <maximumValue>100</maximumValue>
                 <legibleDescription>

--- a/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_HT_RestAPICloud_V0.1.xml
@@ -102,11 +102,11 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>

--- a/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_TRV_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_00_mmmm_dddd_Shelly_TRV_RestAPICloud_V0.1.xml
@@ -18,21 +18,21 @@
   <deviceInformation>
     <legibleDescription>
       <textElement>
-        <![CDATA[ 
-          Der Shelly TRV ist ein steuerbarer Heizkörper-Thermostat.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API ausgelegt.
-          Das Setzen der Zieltemperatur ist via Cloud nicht möglich.
+        <![CDATA[
+          <p>Der Shelly TRV ist ein steuerbarer Heizkörper-Thermostat.<br />
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API ausgelegt.</p>
+          <p>Das Setzen der Zieltemperatur ist via Cloud REST API nicht möglich.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-trv-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-trv</uri>
     </legibleDescription>
     <deviceCategory>HeatingObject</deviceCategory>
     <isLocalControl>false</isLocalControl>
     <softwareRevision>1.0.0</softwareRevision>
     <hardwareRevision>1.0.0</hardwareRevision>
     <manufacturerSpecificationIdentification>Shelly</manufacturerSpecificationIdentification>
-    <levelOfOperation>4m</levelOfOperation>
+    <levelOfOperation>m</levelOfOperation>
     <versionNumber>
       <primaryVersionNumber>0</primaryVersionNumber>
       <secondaryVersionNumber>1</secondaryVersionNumber>
@@ -63,7 +63,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>ShellyTRV</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -103,35 +103,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -147,7 +200,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>
@@ -178,12 +231,12 @@
         </functionalProfileListElement>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>Thermostat</functionalProfileName>
+            <functionalProfileName>Temperature</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
-              <functionalProfileType>Thermostat</functionalProfileType>
-              <levelOfOperation>4m</levelOfOperation>
+              <functionalProfileCategory>TemperatureSensor</functionalProfileCategory>
+              <functionalProfileType>Temperature</functionalProfileType>
+              <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
@@ -192,13 +245,13 @@
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht die Steuerung der Zieltemperatur.
+                Ermöglicht das Auslesen der Temperaturen.
               </textElement>
               <language>de</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows controlling the target temperature.
+                Allows reading temperatures.
               </textElement>
               <language>en</language>
             </legibleDescription>
@@ -251,6 +304,36 @@
                 </restApiReadServiceCall>
               </restApiDataPointConfiguration>
             </dataPointListElement>
+          </dataPointList>
+        </functionalProfileListElement>
+        <functionalProfileListElement>
+          <functionalProfile>
+            <functionalProfileName>Thermostat</functionalProfileName>
+            <functionalProfileIdentification>
+              <specificationOwnerIdentification>0</specificationOwnerIdentification>
+              <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
+              <functionalProfileType>Thermostat</functionalProfileType>
+              <levelOfOperation>m</levelOfOperation>
+              <versionNumber>
+                <primaryVersionNumber>0</primaryVersionNumber>
+                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+              </versionNumber>
+            </functionalProfileIdentification>
+            <legibleDescription>
+              <textElement>
+                Ermöglicht das Auslesen der Zieltemperatur.
+              </textElement>
+              <language>de</language>
+            </legibleDescription>
+            <legibleDescription>
+              <textElement>
+                Allows reading the target temperature.
+              </textElement>
+              <language>en</language>
+            </legibleDescription>
+          </functionalProfile>
+          <dataPointList>
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>TargetTemperature</dataPointName>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPICloud_V0.1.xml
@@ -18,13 +18,13 @@
   <deviceInformation>
     <legibleDescription>
       <textElement>
-        <![CDATA[ 
-          Der Shelly 1PM ist ein 1-phasiges Leistungsmessgerät mit schaltbarem Relais.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.
+        <![CDATA[
+          <p>Der Shelly 1PM ist ein 1-phasiges Leistungsmessgerät mit schaltbarem Relais.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-plus-1-pm</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-plus-1-pm</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>false</isLocalControl>
@@ -62,7 +62,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>Shelly1PM</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -102,35 +102,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -146,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>
@@ -245,9 +298,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>4000</maximumValue>
+                <maximumValue>4</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -360,8 +414,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
-                <unitConversionMultiplicator>0.01666666666667</unitConversionMultiplicator>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPICloud_V0.1.xml
@@ -415,7 +415,7 @@
                   <float64 />
                 </dataType>
                 <unit>KILOWATT_HOURS</unit>
-                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
+                <unitConversionMultiplicator>0.00001666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPILocal_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly 1PM ist ein 1-phasiges Leistungsmessgerät mit schaltbarem Relais.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.
+          <p>Der Shelly 1PM ist ein 1-phasiges Leistungsmessgerät mit schaltbarem Relais.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-plus-1-pm</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-plus-1-pm</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>true</isLocalControl>
@@ -136,9 +136,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>4000</maximumValue>
+                <maximumValue>4</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -241,8 +242,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
-                <unitConversionMultiplicator>0.01666666666667</unitConversionMultiplicator>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1PM_RestAPILocal_V0.1.xml
@@ -243,7 +243,7 @@
                   <float64 />
                 </dataType>
                 <unit>KILOWATT_HOURS</unit>
-                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
+                <unitConversionMultiplicator>0.00001666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1_RestAPICloud_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly 1 ist ein 1-kanaliges schaltbares Relais.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.
+          <p>Der Shelly 1 ist ein 1-kanaliges schaltbares Relais.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>false</isLocalControl>
@@ -62,7 +62,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>Shelly1</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -102,35 +102,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -146,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_1_RestAPILocal_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly 1 ist ein 1-kanaliges schaltbares Relais.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.
+          <p>Der Shelly 1 ist ein 1-kanaliges schaltbares Relais.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>true</isLocalControl>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_3EM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_3EM_RestAPICloud_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly 3EM ist ein 3-Phasen-Energiezähler mit schaltbarem Relais.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.
+          <p>Der Shelly 3EM ist ein 3-Phasen-Energiezähler mit schaltbarem Relais.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-3em-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base//shelly-3em-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>false</isLocalControl>
@@ -62,7 +62,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>Shelly3EM</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -102,35 +102,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -146,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>
@@ -245,9 +298,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>90000</maximumValue>
+                <maximumValue>90</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -292,9 +346,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 1</textElement>
                   <language>de</language>
@@ -339,9 +394,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 2</textElement>
                   <language>de</language>
@@ -386,9 +442,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 3</textElement>
                   <language>de</language>
@@ -501,7 +558,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>
@@ -546,7 +604,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 1</textElement>
                   <language>de</language>
@@ -591,7 +650,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 2</textElement>
                   <language>de</language>
@@ -636,7 +696,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 3</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_3EM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_3EM_RestAPILocal_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly 3EM ist ein 3-Phasen-Energiezähler mit schaltbarem Relais.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.
+          <p>Der Shelly 3EM ist ein 3-Phasen-Energiezähler mit schaltbarem Relais.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-3em-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base//shelly-3em-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>true</isLocalControl>
@@ -136,9 +136,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>90000</maximumValue>
+                <maximumValue>90</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -173,9 +174,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 1</textElement>
                   <language>de</language>
@@ -210,9 +212,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 2</textElement>
                   <language>de</language>
@@ -247,9 +250,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>30000</maximumValue>
+                <maximumValue>30</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkleistung Phase 3</textElement>
                   <language>de</language>
@@ -352,7 +356,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>
@@ -387,7 +392,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 1</textElement>
                   <language>de</language>
@@ -422,7 +428,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 2</textElement>
                   <language>de</language>
@@ -457,7 +464,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der Wirkenergie Phase 3</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Plus1_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Plus1_RestAPICloud_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Plus 1 ist ein 1-kanaliges Relais.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Plus 1 ist ein 1-kanaliges Relais.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud JSON-RPC API (Gen2) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-plus-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-plus-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>false</isLocalControl>
@@ -62,7 +62,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>ShellyPlus1</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -102,35 +102,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -146,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Plus1_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Plus1_RestAPILocal_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Plus 1 ist ein 1-kanaliges Relais.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Plus 1 ist ein 1-kanaliges Relais.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-plus-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-plus-1</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>true</isLocalControl>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPICloud_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Pro 1PM ist ein 1-phasiges 1-Kanal-Leistungsmessgerät.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Pro 1PM ist ein 1-phasiges 1-Kanal-Leistungsmessgerät.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de/products/shelly-pro-1pm</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-pro-1pm</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>false</isLocalControl>
@@ -62,7 +62,7 @@
       <dataType>
         <string />
       </dataType>
-      <defaultValue>ShellyPro1PM</defaultValue>
+      <defaultValue>000000000000</defaultValue>
       <configurationDescription>
         <textElement>ID of the cloud device.</textElement>
         <language>en</language>
@@ -79,6 +79,7 @@
       <dataType>
         <string />
       </dataType>
+      <defaultValue></defaultValue>
       <configurationDescription>
         <textElement>Cloud authentication key.</textElement>
         <language>en</language>
@@ -101,35 +102,88 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>DeviceStatus</functionalProfileName>
+            <functionalProfileName>DeviceInformation</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
               <functionalProfileCategory>DeviceInformation</functionalProfileCategory>
-              <functionalProfileType>DeviceStatus</functionalProfileType>
+              <functionalProfileType>DeviceInformation</functionalProfileType>
               <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
-                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+                <subReleaseVersionNumber>1</subReleaseVersionNumber>
               </versionNumber>
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht das Auslesen des Gerätestatus.
+                <![CDATA[
+          Functional profile used to read a device ID used to identify a device. <p>
+          Further on, this functional profile that can be used for vendor specific information and data points. <p>
+          It allows the handling of data points, which are valid for the whole device.
+        ]]>
               </textElement>
-              <language>de</language>
+              <language>en</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows reading the device status.
+                <![CDATA[
+          Funktionsprofil zum Auslesen einer Geräte ID zur Identifikation des Geräts. <p>
+          Weiterhin kann das Funktionsprofil für herstellerspezifische Informationen und Datenpunkte benutzt werden. <p>
+          Es ermöglicht das Handling von Datenpunkten, welche für das ganze Gerät gelten.
+        ]]>
               </textElement>
-              <language>en</language>
+              <language>de</language>
             </legibleDescription>
           </functionalProfile>
           <dataPointList>
             <dataPointListElement>
               <dataPoint>
-                <dataPointName>ConnectionStatus</dataPointName>
+                <dataPointName>DeviceId</dataPointName>
+                <dataDirection>R</dataDirection>
+                <dataType>
+                  <string />
+                </dataType>
+                <unit>NONE</unit>
+                <legibleDescription>
+                  <textElement>Read the device ID.</textElement>
+                  <language>en</language>
+                </legibleDescription>
+                <legibleDescription>
+                  <textElement>Auslesen der Geräte ID.</textElement>
+                  <language>de</language>
+                </legibleDescription>
+              </dataPoint>
+              <restApiDataPointConfiguration>
+                <dataType>JSON_string</dataType>
+                <restApiReadServiceCall>
+                  <requestHeader>
+                    <header>
+                      <headerName>Accept</headerName>
+                      <value>application/json</value>
+                    </header>
+                  </requestHeader>
+                  <requestMethod>POST</requestMethod>
+                  <requestPath>/device/status</requestPath>
+                  <requestForm>
+                    <parameter>
+                      <name>id</name>
+                      <value>{{device_id}}</value>
+                    </parameter>
+                    <parameter>
+                      <name>auth_key</name>
+                      <value>{{auth_key}}</value>
+                    </parameter>
+                  </requestForm>
+                  <responseQuery>
+                    <queryType>JMESPathExpression</queryType>
+                    <query>data.device_status.id</query>
+                  </responseQuery>
+                </restApiReadServiceCall>
+              </restApiDataPointConfiguration>
+            </dataPointListElement>
+            <dataPointListElement>
+              <dataPoint>
+                <dataPointName>Online</dataPointName>
                 <dataDirection>R</dataDirection>
                 <dataType>
                   <boolean />
@@ -145,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>
@@ -244,9 +298,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>4000</maximumValue>
+                <maximumValue>4</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -359,7 +414,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPICloud_V0.1.xml
@@ -415,7 +415,7 @@
                   <float64 />
                 </dataType>
                 <unit>KILOWATT_HOURS</unit>
-                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
+                <unitConversionMultiplicator>0.00001666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPILocal_V0.1.xml
@@ -19,8 +19,8 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Pro 1PM ist ein 1-phasiges 1-Kanal-Leistungsmessgerät.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Pro 1PM ist ein 1-phasiges 1-Kanal-Leistungsmessgerät.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
@@ -136,9 +136,10 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATTS</unit>
+                <unit>KILOWATTS</unit>
                 <minimumValue>0</minimumValue>
-                <maximumValue>4000</maximumValue>
+                <maximumValue>4</maximumValue>
+                <unitConversionMultiplicator>0.001</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkleistung</textElement>
                   <language>de</language>
@@ -247,7 +248,8 @@
                 <dataType>
                   <float64 />
                 </dataType>
-                <unit>WATT_HOURS</unit>
+                <unit>KILOWATT_HOURS</unit>
+                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro1PM_RestAPILocal_V0.1.xml
@@ -249,7 +249,7 @@
                   <float64 />
                 </dataType>
                 <unit>KILOWATT_HOURS</unit>
-                <unitConversionMultiplicator>0.0001666666666667</unitConversionMultiplicator>
+                <unitConversionMultiplicator>0.00001666666667</unitConversionMultiplicator>
                 <legibleDescription>
                   <textElement>Erfassung der gesamten Wirkenergie</textElement>
                   <language>de</language>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_MQTT_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_MQTT_V0.1.xml
@@ -18,14 +18,12 @@
   <deviceInformation>
     <legibleDescription>
       <textElement>
-        <![CDATA[ 
-          Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.
-          Die vorliegende EID ist auf die Ansteuerung via MQTT ausgelegt.
-          
-          Mit der vorliegenden EID können Daten via MQTT-Topic "{topic_prefix}/status" empfangen werden.
-          In der Firmware muss MQTT Control aktiviert sein und RPC via MQTT deaktiviert.
-          
-          Schreiben der Relais geht in dieser Version der EID noch nicht, da dies eine Anpassug der Spezifikation und Library erfordert.
+        <![CDATA[
+          <p>Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.<br />
+          Die vorliegende EID ist auf die Ansteuerung via MQTT ausgelegt.</p>
+          <p>Mit der vorliegenden EID können Daten via MQTT-Topic <pre>{topic_prefix}/status</pre> empfangen werden.
+          In der Firmware muss MQTT Control aktiviert sein und RPC via MQTT deaktiviert.</p>
+          <p>Schreiben der Relais geht in dieser Version der EID noch nicht, da dies noch eine Anpassung der Spezifikation und Library erfordert.</p>
         ]]>
       </textElement>
       <language>de</language>
@@ -1488,7 +1486,7 @@
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>Relais</dataPointName>
-                <dataDirection>R</dataDirection>
+                <dataDirection>RW</dataDirection>
                 <dataType>
                   <boolean />
                 </dataType>
@@ -1544,7 +1542,7 @@
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>Relais</dataPointName>
-                <dataDirection>R</dataDirection>
+                <dataDirection>RW</dataDirection>
                 <dataType>
                   <boolean />
                 </dataType>
@@ -1600,7 +1598,7 @@
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>Relais</dataPointName>
-                <dataDirection>R</dataDirection>
+                <dataDirection>RW</dataDirection>
                 <dataType>
                   <boolean />
                 </dataType>
@@ -1656,7 +1654,7 @@
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>Relais</dataPointName>
-                <dataDirection>R</dataDirection>
+                <dataDirection>RW</dataDirection>
                 <dataType>
                   <boolean />
                 </dataType>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_RestAPICloud_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_RestAPICloud_V0.1.xml
@@ -19,8 +19,8 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.
-          Die vorliegende EID ist auf die Ansteuerung via Cloud JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.
+          Die vorliegende EID ist auf die Ansteuerung via Cloud REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
@@ -154,7 +154,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_string</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>
@@ -199,7 +199,7 @@
                 </legibleDescription>
               </dataPoint>
               <restApiDataPointConfiguration>
-                <dataType>JSON_number</dataType>
+                <dataType>JSON_boolean</dataType>
                 <restApiReadServiceCall>
                   <requestHeader>
                     <header>

--- a/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_01_mmmm_dddd_Shelly_Pro4PM_RestAPILocal_V0.1.xml
@@ -19,12 +19,12 @@
     <legibleDescription>
       <textElement>
         <![CDATA[ 
-          Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.
+          <p>Der Shelly Pro 4PM ist ein 1-phasiges 4-Kanal-Leistungsmessgerät.
+          Die vorliegende EID ist auf die Ansteuerung via lokalem JSON-RPC API (Gen2) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-pro-4pm-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-pro-4pm</uri>
     </legibleDescription>
     <deviceCategory>SubMeterElectricity</deviceCategory>
     <isLocalControl>true</isLocalControl>

--- a/XMLInstances/ExtInterfaces/SGr_02_0015_xxxx_StiebelEltron_HeatPump_V1.0.0.xml
+++ b/XMLInstances/ExtInterfaces/SGr_02_0015_xxxx_StiebelEltron_HeatPump_V1.0.0.xml
@@ -70,7 +70,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_02_4893879785_8288144069_SwiSBox_SubMeterElectricity_V1.0.0.xml
+++ b/XMLInstances/ExtInterfaces/SGr_02_4893879785_8288144069_SwiSBox_SubMeterElectricity_V1.0.0.xml
@@ -28,7 +28,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_0005_xxxx_GARO_WallboxV0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_0005_xxxx_GARO_WallboxV0.2.1.xml
@@ -75,7 +75,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_0015_xxxx_StiebelEltron_HeatPumpV0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_0015_xxxx_StiebelEltron_HeatPumpV0.2.1.xml
@@ -78,7 +78,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_0015_xxxx_StiebelEltron_HeatPump_V1.0.0.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_0015_xxxx_StiebelEltron_HeatPump_V1.0.0.xml
@@ -79,7 +79,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_0019_0059_VGT_SPSDeviceforHomeAutomation_v0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_0019_0059_VGT_SPSDeviceforHomeAutomation_v0.2.1.xml
@@ -69,7 +69,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_0021_xxxx_FroniusSymoV0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_0021_xxxx_FroniusSymoV0.2.1.xml
@@ -39,7 +39,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_Shelly_TRV_RestAPILocal_V0.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_Shelly_TRV_RestAPILocal_V0.1.xml
@@ -18,13 +18,13 @@
   <deviceInformation>
     <legibleDescription>
       <textElement>
-        <![CDATA[ 
-          Der Shelly TRV ist ein steuerbarer Heizkörper-Thermostat.
-          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen2) ausgelegt.
+        <![CDATA[
+          <p>Der Shelly TRV ist ein steuerbarer Heizkörper-Thermostat.<br />
+          Die vorliegende EID ist auf die Ansteuerung via lokalem REST API (Gen1) ausgelegt.</p>
         ]]>
       </textElement>
       <language>de</language>
-      <uri>https://www.shelly.com/de-ch/products/product-overview/shelly-trv-1</uri>
+      <uri>https://kb.shelly.cloud/knowledge-base/shelly-trv</uri>
     </legibleDescription>
     <deviceCategory>HeatingObject</deviceCategory>
     <isLocalControl>true</isLocalControl>
@@ -68,12 +68,12 @@
       <functionalProfileList>
         <functionalProfileListElement>
           <functionalProfile>
-            <functionalProfileName>Thermostat</functionalProfileName>
+            <functionalProfileName>Temperature</functionalProfileName>
             <functionalProfileIdentification>
               <specificationOwnerIdentification>0</specificationOwnerIdentification>
-              <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
-              <functionalProfileType>Thermostat</functionalProfileType>
-              <levelOfOperation>4m</levelOfOperation>
+              <functionalProfileCategory>TemperatureSensor</functionalProfileCategory>
+              <functionalProfileType>Temperature</functionalProfileType>
+              <levelOfOperation>m</levelOfOperation>
               <versionNumber>
                 <primaryVersionNumber>0</primaryVersionNumber>
                 <secondaryVersionNumber>1</secondaryVersionNumber>
@@ -82,13 +82,13 @@
             </functionalProfileIdentification>
             <legibleDescription>
               <textElement>
-                Ermöglicht die Steuerung der Zieltemperatur.
+                Ermöglicht Auslesen der Temperaturen.
               </textElement>
               <language>de</language>
             </legibleDescription>
             <legibleDescription>
               <textElement>
-                Allows controlling the target temperature.
+                Allows reading temperatures.
               </textElement>
               <language>en</language>
             </legibleDescription>
@@ -131,6 +131,36 @@
                 </restApiReadServiceCall>
               </restApiDataPointConfiguration>
             </dataPointListElement>
+          </dataPointList>
+        </functionalProfileListElement>
+        <functionalProfileListElement>
+          <functionalProfile>
+            <functionalProfileName>Thermostat</functionalProfileName>
+            <functionalProfileIdentification>
+              <specificationOwnerIdentification>0</specificationOwnerIdentification>
+              <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
+              <functionalProfileType>Thermostat</functionalProfileType>
+              <levelOfOperation>4m</levelOfOperation>
+              <versionNumber>
+                <primaryVersionNumber>0</primaryVersionNumber>
+                <secondaryVersionNumber>1</secondaryVersionNumber>
+                <subReleaseVersionNumber>0</subReleaseVersionNumber>
+              </versionNumber>
+            </functionalProfileIdentification>
+            <legibleDescription>
+              <textElement>
+                Ermöglicht Auslesen und Steuern der Zieltemperatur.
+              </textElement>
+              <language>de</language>
+            </legibleDescription>
+            <legibleDescription>
+              <textElement>
+                Allows reading and controlling the target temperature.
+              </textElement>
+              <language>en</language>
+            </legibleDescription>
+          </functionalProfile>
+          <dataPointList>
             <dataPointListElement>
               <dataPoint>
                 <dataPointName>TargetTemperature</dataPointName>

--- a/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_WallboxAsymV0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_WallboxAsymV0.2.1.xml
@@ -61,7 +61,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_WallboxV0.2.1.xml
+++ b/XMLInstances/ExtInterfaces/SGr_04_mmmm_dddd_WallboxV0.2.1.xml
@@ -61,7 +61,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/ExtInterfaces/mvpEi4Modbus_0000_0036_0030_4_0.1_SGCP_BiDirFlexMgmt.xml
+++ b/XMLInstances/ExtInterfaces/mvpEi4Modbus_0000_0036_0030_4_0.1_SGCP_BiDirFlexMgmt.xml
@@ -49,7 +49,7 @@
       <dataType>
         <string/>
       </dataType>
-      <defaultValue></defaultValue>
+      <defaultValue>0.0.0.0</defaultValue>
       <configurationDescription>
         <textElement>The IP address</textElement>
         <language>en</language>

--- a/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_PowerQuadrant.xml
+++ b/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_PowerQuadrant.xml
@@ -27,7 +27,7 @@
         <dataType>
           <float64/>
         </dataType>
-        <unit>NONE</unit>
+        <unit>KILOWATT_HOURS</unit>
       </dataPoint>
     </dataPointListElement>
     <dataPointListElement>

--- a/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_PowerQuadrant.xml
+++ b/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_PowerQuadrant.xml
@@ -27,7 +27,7 @@
         <dataType>
           <float64/>
         </dataType>
-        <unit>KILOWATT_HOURS</unit>
+        <unit>NONE</unit>
       </dataPoint>
     </dataPointListElement>
     <dataPointListElement>
@@ -38,7 +38,7 @@
         <dataType>
           <float64/>
         </dataType>
-        <unit>KILOWATT_HOURS</unit>
+        <unit>NONE</unit>
       </dataPoint>
     </dataPointListElement>
     <dataPointListElement>
@@ -49,7 +49,7 @@
         <dataType>
           <float64/>
         </dataType>
-        <unit>KILOWATT_HOURS</unit>
+        <unit>NONE</unit>
       </dataPoint>
     </dataPointListElement>
     <dataPointListElement>
@@ -60,7 +60,7 @@
         <dataType>
           <float64/>
         </dataType>
-        <unit>KILOWATT_HOURS</unit>
+        <unit>NONE</unit>
       </dataPoint>
     </dataPointListElement>
   </dataPointList>

--- a/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_ReactiveEnergyBalanceAC2.xml
+++ b/XMLInstances/FuncProfiles/FP_0_0011_13_4_0.2_ReactiveEnergyBalanceAC2.xml
@@ -8,7 +8,7 @@
   <functionalProfile>
     <functionalProfileIdentification>
       <specificationOwnerIdentification>0</specificationOwnerIdentification>
-      <functionalProfileCategory>SubMeterElectricity</functionalProfileCategory>
+      <functionalProfileCategory>Metering</functionalProfileCategory>
       <functionalProfileType>ReactiveEnergyBalanceAC</functionalProfileType>
       <levelOfOperation>m</levelOfOperation>
       <versionNumber>

--- a/XMLInstances/FuncProfiles/FP_SGr_HeatingCircuit_Thermostat_4m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_HeatingCircuit_Thermostat_4m_0.1.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xsl/SGr.xsl"?>
+<FunctionalProfileFrame xmlns="http://www.smartgridready.com/ns/V0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/SGrIncluder.xsd">
+  <releaseNotes>
+    <state>Draft</state>
+    <changeLog>
+      <version>0.1.0</version>
+      <date>2024-10-16</date>
+      <author>Matthias Krebs, FHNW</author>
+      <comment>Draft for Testlab</comment>
+    </changeLog>
+  </releaseNotes>
+  <functionalProfile>
+    <functionalProfileIdentification>
+      <specificationOwnerIdentification>0</specificationOwnerIdentification>
+      <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
+      <functionalProfileType>Thermostat</functionalProfileType>
+      <levelOfOperation>4m</levelOfOperation>
+      <versionNumber>
+        <primaryVersionNumber>0</primaryVersionNumber>
+        <secondaryVersionNumber>1</secondaryVersionNumber>
+        <subReleaseVersionNumber>0</subReleaseVersionNumber>
+      </versionNumber>
+    </functionalProfileIdentification>
+    <legibleDescription>
+      <textElement>
+        Ermöglicht Auslesen und Steuern der Zieltemperatur.
+      </textElement>
+      <language>de</language>
+    </legibleDescription>
+    <legibleDescription>
+      <textElement>
+        Allows reading and controlling the target temperature.
+      </textElement>
+    <language>en</language>
+  </legibleDescription>
+  </functionalProfile>
+  <dataPointList>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>TargetTemperature</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>DEGREES_CELSIUS</unit>
+        <legibleDescription>
+          <textElement>Einstellung der Zieltemperatur</textElement>
+          <language>de</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Setting of the target temperature</textElement>
+          <language>en</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+  </dataPointList>
+</FunctionalProfileFrame>

--- a/XMLInstances/FuncProfiles/FP_SGr_HeatingCircuit_Thermostat_m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_HeatingCircuit_Thermostat_m_0.1.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xsl/SGr.xsl"?>
+<FunctionalProfileFrame xmlns="http://www.smartgridready.com/ns/V0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/SGrIncluder.xsd">
+  <releaseNotes>
+    <state>Draft</state>
+    <changeLog>
+      <version>0.1.0</version>
+      <date>2024-10-16</date>
+      <author>Matthias Krebs, FHNW</author>
+      <comment>Draft for Testlab</comment>
+    </changeLog>
+  </releaseNotes>
+  <functionalProfile>
+    <functionalProfileIdentification>
+      <specificationOwnerIdentification>0</specificationOwnerIdentification>
+      <functionalProfileCategory>HeatingCircuit</functionalProfileCategory>
+      <functionalProfileType>Thermostat</functionalProfileType>
+      <levelOfOperation>m</levelOfOperation>
+      <versionNumber>
+        <primaryVersionNumber>0</primaryVersionNumber>
+        <secondaryVersionNumber>1</secondaryVersionNumber>
+        <subReleaseVersionNumber>0</subReleaseVersionNumber>
+      </versionNumber>
+    </functionalProfileIdentification>
+    <legibleDescription>
+      <textElement>
+        Ermöglicht Auslesen der Zieltemperatur.
+      </textElement>
+      <language>de</language>
+    </legibleDescription>
+    <legibleDescription>
+      <textElement>
+        Allows reading the target temperature.
+      </textElement>
+    <language>en</language>
+  </legibleDescription>
+  </functionalProfile>
+  <dataPointList>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>TargetTemperature</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>DEGREES_CELSIUS</unit>
+        <legibleDescription>
+          <textElement>Einstellung der Zieltemperatur</textElement>
+          <language>de</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Setting of the target temperature</textElement>
+          <language>en</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+  </dataPointList>
+</FunctionalProfileFrame>

--- a/XMLInstances/FuncProfiles/FP_SGr_Sensor_Humidity_m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_Sensor_Humidity_m_0.1.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xsl/SGr.xsl"?>
+<FunctionalProfileFrame xmlns="http://www.smartgridready.com/ns/V0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/SGrIncluder.xsd">
+  <releaseNotes>
+    <state>Draft</state>
+    <changeLog>
+      <version>0.1.0</version>
+      <date>2024-10-16</date>
+      <author>Matthias Krebs, FHNW</author>
+      <comment>Draft</comment>
+    </changeLog>
+  </releaseNotes>
+  <functionalProfile>
+    <functionalProfileIdentification>
+      <specificationOwnerIdentification>0</specificationOwnerIdentification>
+      <functionalProfileCategory>Sensor</functionalProfileCategory>
+      <functionalProfileType>Humidity</functionalProfileType>
+      <levelOfOperation>m</levelOfOperation>
+      <versionNumber>
+        <primaryVersionNumber>0</primaryVersionNumber>
+        <secondaryVersionNumber>1</secondaryVersionNumber>
+        <subReleaseVersionNumber>0</subReleaseVersionNumber>
+      </versionNumber>
+    </functionalProfileIdentification>
+    <legibleDescription>
+      <textElement>
+        Ermöglicht Auslesen der Feuchtigkeit.
+      </textElement>
+      <language>de</language>
+    </legibleDescription>
+    <legibleDescription>
+      <textElement>
+        Allows reading humdity.
+      </textElement>
+    <language>en</language>
+  </legibleDescription>
+  </functionalProfile>
+  <dataPointList>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>Humidity</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>PERCENT_RELATIVE_HUMIDITY</unit>
+        <legibleDescription>
+          <textElement>Messung der Feuchtigkeit</textElement>
+          <language>de</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Humidity measurement</textElement>
+          <language>en</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+  </dataPointList>
+</FunctionalProfileFrame>

--- a/XMLInstances/FuncProfiles/FP_SGr_TemperatureSensor_Temperature_m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_TemperatureSensor_Temperature_m_0.1.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xsl/SGr.xsl"?>
+<FunctionalProfileFrame xmlns="http://www.smartgridready.com/ns/V0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/SGrIncluder.xsd">
+  <releaseNotes>
+    <state>Draft</state>
+    <changeLog>
+      <version>0.1.0</version>
+      <date>2024-10-16</date>
+      <author>Matthias Krebs, FHNW</author>
+      <comment>Draft</comment>
+    </changeLog>
+  </releaseNotes>
+  <functionalProfile>
+    <functionalProfileIdentification>
+      <specificationOwnerIdentification>0</specificationOwnerIdentification>
+      <functionalProfileCategory>TemperatureSensor</functionalProfileCategory>
+      <functionalProfileType>Temperature</functionalProfileType>
+      <levelOfOperation>m</levelOfOperation>
+      <versionNumber>
+        <primaryVersionNumber>0</primaryVersionNumber>
+        <secondaryVersionNumber>1</secondaryVersionNumber>
+        <subReleaseVersionNumber>0</subReleaseVersionNumber>
+      </versionNumber>
+    </functionalProfileIdentification>
+    <legibleDescription>
+      <textElement>
+        Ermöglicht Auslesen der Temperaturen.
+      </textElement>
+      <language>de</language>
+    </legibleDescription>
+    <legibleDescription>
+      <textElement>
+        Allows reading temperatures.
+      </textElement>
+    <language>en</language>
+  </legibleDescription>
+  </functionalProfile>
+  <dataPointList>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>Temperature</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>DEGREES_CELSIUS</unit>
+        <legibleDescription>
+          <textElement>Messung der Temperatur</textElement>
+          <language>de</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Temperature measurement</textElement>
+          <language>en</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+  </dataPointList>
+</FunctionalProfileFrame>


### PR DESCRIPTION
- added drafts of missing FPs, so that Shelly EIDs do not reference non-existent FPs
- corrected PowerQuadrant FP (data type)
- corrected units and data types of ABB B23 RTU+TCP
- corrected various Shelly EIDs, harmonized DeviceInformation FP
- set a valid default IP address to Modbus TCP devices, avoids validation error when loading with no properties

verified with validator tool.




**please squash to avoid unnecessary intermediate commits**