### PR TITLE
Fp evcharginghubcurtailment 4m

### DIFF
--- a/XMLInstances/FuncProfiles/FP_SGr_SGCP_EvChargingHubCurtailment_4m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_SGCP_EvChargingHubCurtailment_4m_0.1.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xsl/SGr.xsl"?>
+<FunctionalProfileFrame xmlns="http://www.smartgridready.com/ns/V0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.smartgridready.com/ns/V0/ ../../SchemaDatabase/SGr/SGrIncluder.xsd">
+  <releaseNotes>
+    <state>Draft</state>
+    <changeLog>
+      <version>0.1.0</version>
+      <date>2026-07-08</date>
+      <author>SGr/kar</author>
+      <comment>Initial draft</comment>
+    </changeLog>
+  </releaseNotes>
+  <functionalProfile>
+    <functionalProfileIdentification>
+      <specificationOwnerIdentification>0</specificationOwnerIdentification>
+      <functionalProfileCategory>SGCP</functionalProfileCategory>
+      <functionalProfileType>EvChargingHubCurtailment</functionalProfileType>
+      <levelOfOperation>4m</levelOfOperation>
+      <versionNumber>
+        <primaryVersionNumber>0</primaryVersionNumber>
+        <secondaryVersionNumber>1</secondaryVersionNumber>
+        <subReleaseVersionNumber>0</subReleaseVersionNumber>
+      </versionNumber>
+    </functionalProfileIdentification>
+    <legibleDescription>
+      <textElement>
+        <![CDATA[
+          <p><b>Controlling functional profile for the dynamic curtailment of load at the grid connection point of an EV charging park</b></p>
+
+          <p>This functional profile is used by a flexibility manager, for example a grid control system (SCADA), to control a charging park via an Energy Management System (EMS) or directly via the charging controller, and to limit the AC-side active power consumption at the grid connection point. For integration, protocols such as Modbus TCP as well as manufacturer-specific local or cloud interfaces can be used.</p>
+
+          <p>The limitation of the AC-side load (consumption) active power can be implemented either as an absolute value in kilowatts (ActivePowerMaxLoad) or as a relative value in percent referenced to the installed nominal power of the charging park (ActivePowerMaxPercentLoad). Both data points are marked as mandatory (M) in the profile and form an alternative requirement group. A compliant implementation must support at least one of these two data points.</p>
+
+          <p>In the event of a communication failure, the charging park shall hold the last received limitation value and restore it from non-volatile memory after an auxiliary power failure.</p>
+
+          <p>The data point for the active power at the grid connection point (ActivePowerMeasured) is also mandatory. The implementation of additional data points is recommended, especially for providing reactive power setpoints at the grid connection point. Optional measurements such as the cumulative active energy at the grid connection point (EnergyMeasured) and the application-level life sign (Heartbeat) can be helpful for operation.</p>
+
+          <p>In a product declaration, data points with read and write access can either be mapped to the same logical endpoint or split into separate setpoint values and actual values, for example into different Modbus registers or corresponding objects in other communication standards.</p>
+        ]]>
+      </textElement>
+      <language>en</language>
+    </legibleDescription>
+    <legibleDescription>
+      <textElement>
+        <![CDATA[
+          <p><b>Steuerndes Funktionsprofil für die dynamische Begrenzung des Bezugs am Netzanschlusspunkt eines Ladeparks</b></p>
+
+          <p>Dieses Funktionsprofil wird von einem Flexibilitätsmanager, zum Beispiel mit einem Netzleitsystem (SCADA), verwendet, um einen Ladepark über ein Energy Management System (EMS) oder direkt über den Laderegler anzusteuern und die AC-seitige Wirkleistungsaufnahme am Netzanschlusspunkt zu begrenzen. Für die Anbindung können Protokolle wie Modbus TCP sowie herstellerspezifische lokale oder Cloud-Schnittstellen eingesetzt werden.</p>
+
+          <p>Die Begrenzung der AC-seitigen Wirkleistungsaufnahme (Bezug) kann entweder über einen absoluten Wert in Kilowatt (ActivePowerMaxLoad) oder über einen relativen Wert in Prozent bezogen auf die installierte Nennleistung des Ladeparks erfolgen (ActivePowerMaxPercentLoad). Beide Datenpunkte sind im Profil als Mandatory (M) gekennzeichnet und bilden gemeinsam eine alternative Anforderungsgruppe. Eine konforme Implementierung muss mindestens einen der beiden Datenpunkte unterstützen.</p>
+
+          <p>Der Ladepark soll bei einem Kommunikationsausfall den zuletzt empfangenen Begrenzungswert halten und stellt ihn nach einem Hilfsspannungsausfall aus einem nichtflüchtigen Speicher wieder her.</p>
+
+          <p>Der Datenpunkt für die Wirkleistung am Netzanschlusspunkt (ActivePowerMeasured) ist ebenfalls Pflicht. Die Umsetzung weiterer Datenpunkte wird empfohlen, insbesondere zur Vorgabe von Blindleistungs-Sollwerten am Netzanschlusspunkt. Optionale Messgrössen wie die kumulierte Wirkenergie am Netzanschlusspunkt (EnergyMeasured) und das applikationsseitige Lebenszeichen (Heartbeat) können für den Betrieb hilfreich sein.</p>
+
+          <p>Datenpunkte mit Lese- und Schreibzugriff können in einer Produktdeklaration entweder auf denselben logischen Endpunkt abgebildet werden oder in getrennte Sollwerte (Setpoint Values) und Istwerte (Actual Values) aufgeteilt sein, beispielsweise auf unterschiedliche Modbus-Register oder entsprechende Objekte in anderen Kommunikationsstandards.</p>
+        ]]>
+      </textElement>
+      <language>de</language>
+    </legibleDescription>
+  </functionalProfile>
+  <dataPointList>
+    <!-- Mandatory datapoints -->
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ActivePowerMaxLoad</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOWATTS</unit>
+        <legibleDescription>
+          <textElement>Maximum load (consumption) active power at the grid connection point</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Maximale bezogene Wirkleistung am Netzanschlusspunkt</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ActivePowerMaxPercentLoad</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>PERCENT</unit>
+        <legibleDescription>
+          <textElement>Maximum load (consumption) active power as percentage of installed nominal power [0%...100%]</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Maximale bezogene Wirkleistung als Prozentwert der installierten Nennleistung [0%...100%]</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ActivePowerMeasured</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>M</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOWATTS</unit>
+        <legibleDescription>
+          <textElement>Measured active power at the grid connection point</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Gemessene Wirkleistung am Netzanschlusspunkt</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <!-- Recommended datapoints -->
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>NominalPowerInstalled</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>R</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOWATTS</unit>
+        <legibleDescription>
+          <textElement>Installed AC-side nominal power of the charging park (reference value for percentage-based limits)</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Installierte AC-seitige Nennleistung des Ladeparks (Referenzwert für prozentbasierte Begrenzungen)</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ReactivePowerSetpoint</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>R</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+        <legibleDescription>
+          <textElement>Setpoint for reactive power Q at the grid connection point (absolute value in kVAr), positive: inductive, negative: capacitive</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Sollwert für Blindleistung Q am Netzanschlusspunkt (absoluter Wert in kVAr), positiv: induktiv, negativ: kapazitiv</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ReactivePowerMeasured</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>R</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+        <legibleDescription>
+          <textElement>Measured reactive power at the grid connection point</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Gemessene Blindleistung am Netzanschlusspunkt</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>PowerFactorSetpoint</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>R</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>NONE</unit>
+        <legibleDescription>
+          <textElement>Setpoint for the power factor cosφ [-0.9...0.9], &gt;0 inductive, &lt;0: capacitive. Alternative to ReactivePowerSetpoint</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Sollwert für den Leistungsfaktor cosφ [-0.9...0.9], &gt;0: induktiv, &lt;0: kapazitiv. Alternative zu ReactivePowerSetpoint</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <!-- Optional datapoints -->
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>EnergyMeasured</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>O</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOWATT_HOURS</unit>
+        <legibleDescription>
+          <textElement>Measured cumulative active energy drawn at the grid connection point</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Gemessener Zählerstand der bezogenen Wirkenergie am Netzanschlusspunkt (kumuliert)</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>Heartbeat</dataPointName>
+        <dataDirection>RW</dataDirection>
+        <presenceLevel>O</presenceLevel>
+        <dataType>
+          <boolean />
+        </dataType>
+        <unit>NONE</unit>
+        <legibleDescription>
+          <textElement>Application-level life sign of the charging park controller, enabling the control system to monitor its operational readiness</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Applikationsseitiges Lebenszeichen der Ladepark-Steuerung. Ermöglicht dem Leitsystem die Überwachung der Betriebsbereitschaft</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+  </dataPointList>
+</FunctionalProfileFrame>

--- a/XMLInstances/FuncProfiles/FP_SGr_SGCP_EvChargingHubCurtailment_4m_0.1.xml
+++ b/XMLInstances/FuncProfiles/FP_SGr_SGCP_EvChargingHubCurtailment_4m_0.1.xml
@@ -35,7 +35,7 @@
 
           <p>In the event of a communication failure, the charging park shall hold the last received limitation value and restore it from non-volatile memory after an auxiliary power failure.</p>
 
-          <p>The data point for the active power at the grid connection point (ActivePowerMeasured) is also mandatory. The implementation of additional data points is recommended, especially for providing reactive power setpoints at the grid connection point. Optional measurements such as the cumulative active energy at the grid connection point (EnergyMeasured) and the application-level life sign (Heartbeat) can be helpful for operation.</p>
+          <p>The data point for the active power at the grid connection point (ActivePowerMeasured) is also mandatory. The implementation of additional data points is recommended, especially for providing reactive power setpoints at the grid connection point. Optional measurements such as the cumulative active energy at the grid connection point (EnergyMeasured) and the operational readiness status (Health) can be helpful for operation.</p>
 
           <p>In a product declaration, data points with read and write access can either be mapped to the same logical endpoint or split into separate setpoint values and actual values, for example into different Modbus registers or corresponding objects in other communication standards.</p>
         ]]>
@@ -53,7 +53,7 @@
 
           <p>Der Ladepark soll bei einem Kommunikationsausfall den zuletzt empfangenen Begrenzungswert halten und stellt ihn nach einem Hilfsspannungsausfall aus einem nichtflüchtigen Speicher wieder her.</p>
 
-          <p>Der Datenpunkt für die Wirkleistung am Netzanschlusspunkt (ActivePowerMeasured) ist ebenfalls Pflicht. Die Umsetzung weiterer Datenpunkte wird empfohlen, insbesondere zur Vorgabe von Blindleistungs-Sollwerten am Netzanschlusspunkt. Optionale Messgrössen wie die kumulierte Wirkenergie am Netzanschlusspunkt (EnergyMeasured) und das applikationsseitige Lebenszeichen (Heartbeat) können für den Betrieb hilfreich sein.</p>
+          <p>Der Datenpunkt für die Wirkleistung am Netzanschlusspunkt (ActivePowerMeasured) ist ebenfalls Pflicht. Die Umsetzung weiterer Datenpunkte wird empfohlen, insbesondere zur Vorgabe von Blindleistungs-Sollwerten am Netzanschlusspunkt. Optionale Messgrössen wie die kumulierte Wirkenergie am Netzanschlusspunkt (EnergyMeasured) und die Betriebsbereitschaft (Health) können für den Betrieb hilfreich sein.</p>
 
           <p>Datenpunkte mit Lese- und Schreibzugriff können in einer Produktdeklaration entweder auf denselben logischen Endpunkt abgebildet werden oder in getrennte Sollwerte (Setpoint Values) und Istwerte (Actual Values) aufgeteilt sein, beispielsweise auf unterschiedliche Modbus-Register oder entsprechende Objekte in anderen Kommunikationsstandards.</p>
         ]]>
@@ -161,25 +161,6 @@
     </dataPointListElement>
     <dataPointListElement>
       <dataPoint>
-        <dataPointName>ReactivePowerMeasured</dataPointName>
-        <dataDirection>R</dataDirection>
-        <presenceLevel>R</presenceLevel>
-        <dataType>
-          <float64 />
-        </dataType>
-        <unit>KILOVOLT_AMPERES_REACTIVE</unit>
-        <legibleDescription>
-          <textElement>Measured reactive power at the grid connection point</textElement>
-          <language>en</language>
-        </legibleDescription>
-        <legibleDescription>
-          <textElement>Gemessene Blindleistung am Netzanschlusspunkt</textElement>
-          <language>de</language>
-        </legibleDescription>
-      </dataPoint>
-    </dataPointListElement>
-    <dataPointListElement>
-      <dataPoint>
         <dataPointName>PowerFactorSetpoint</dataPointName>
         <dataDirection>RW</dataDirection>
         <presenceLevel>R</presenceLevel>
@@ -193,6 +174,25 @@
         </legibleDescription>
         <legibleDescription>
           <textElement>Sollwert für den Leistungsfaktor cosφ [-0.9...0.9], &gt;0: induktiv, &lt;0: kapazitiv. Alternative zu ReactivePowerSetpoint</textElement>
+          <language>de</language>
+        </legibleDescription>
+      </dataPoint>
+    </dataPointListElement>
+    <dataPointListElement>
+      <dataPoint>
+        <dataPointName>ReactivePowerMeasured</dataPointName>
+        <dataDirection>R</dataDirection>
+        <presenceLevel>R</presenceLevel>
+        <dataType>
+          <float64 />
+        </dataType>
+        <unit>KILOVOLT_AMPERES_REACTIVE</unit>
+        <legibleDescription>
+          <textElement>Measured reactive power at the grid connection point</textElement>
+          <language>en</language>
+        </legibleDescription>
+        <legibleDescription>
+          <textElement>Gemessene Blindleistung am Netzanschlusspunkt</textElement>
           <language>de</language>
         </legibleDescription>
       </dataPoint>
@@ -219,19 +219,19 @@
     </dataPointListElement>
     <dataPointListElement>
       <dataPoint>
-        <dataPointName>Heartbeat</dataPointName>
-        <dataDirection>RW</dataDirection>
+        <dataPointName>Health</dataPointName>
+        <dataDirection>R</dataDirection>
         <presenceLevel>O</presenceLevel>
         <dataType>
           <boolean />
         </dataType>
         <unit>NONE</unit>
         <legibleDescription>
-          <textElement>Application-level life sign of the charging park controller, enabling the control system to monitor its operational readiness</textElement>
+          <textElement>Health status of the charging park controller. Can be read by the control system to determine whether the charging park is operationally ready</textElement>
           <language>en</language>
         </legibleDescription>
         <legibleDescription>
-          <textElement>Applikationsseitiges Lebenszeichen der Ladepark-Steuerung. Ermöglicht dem Leitsystem die Überwachung der Betriebsbereitschaft</textElement>
+          <textElement>Betriebsbereitschaft (Health) der Ladepark-Steuerung. Kann vom Leitsystem abgefragt werden, um festzustellen, ob der Ladepark einsatzbereit ist</textElement>
           <language>de</language>
         </legibleDescription>
       </dataPoint>


### PR DESCRIPTION
This pull request introduces a new XML functional profile definition for dynamic curtailment of load at the grid connection point of an EV Charging Hub.

**New functional profile for EV charging hub curtailment:**

* Added `FP_SGr_SGCP_EvChargingHubCurtailment_4m_0.1.xml` defining a functional profile for controlling and limiting active power consumption at the grid connection point of an EV charging park, including release notes and detailed descriptions in English and German.

**Data point specification:**

* Defined mandatory data points for active power limitation (`ActivePowerMaxLoad`, `ActivePowerMaxPercentLoad`) and measurement (`ActivePowerMeasured`), ensuring basic interoperability for curtailment control.
* Included recommended data points for nominal power, reactive power setpoints, power factor, and reactive power measurement to support advanced integration scenarios.
* Provided optional data points for cumulative energy measurement (`EnergyMeasured`) and system health status (`Health`) to enhance operational monitoring.